### PR TITLE
fix: DSO-3022 Remove unused bintray plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
   id 'com.diffplug.spotless' version '6.10.0'
-  id 'com.jfrog.bintray' version '1.8.4'
   id 'com.github.ben-manes.versions' version '0.27.0'
   id 'com.github.hierynomus.license' version '0.16.1'
   id 'io.spring.dependency-management' version '1.0.7.RELEASE'
@@ -286,22 +285,7 @@ def getCheckedOutGitCommitHash() {
   refHead.text.trim().take takeFromHash
 }
 
-apply plugin: 'com.jfrog.bintray'
-def bintrayUser = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
-def bintrayKey = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_KEY')
-def bintrayPackage = bintray.pkg {
-  repo = 'pegasys-enterprise-repo'
-  name = 'peeps'
-  userOrg = 'consensys'
-
-  version {
-    name = project.version
-    released = new Date()
-  }
-}
-
 task deploy() {}
-deploy.dependsOn bintrayUpload
 
 tasks.register("verifyDistributions") {
   dependsOn distTar
@@ -321,23 +305,4 @@ tasks.register("verifyDistributions") {
   }
 }
 
-bintray {
-  user = bintrayUser
-  key = bintrayKey
-
-  filesSpec {
-    from ('build/distributions') { exclude 'install/*' }
-    into '.'
-  }
-
-  override = true
-  publish = true
-
-  pkg = bintrayPackage
-}
-
-afterReleaseBuild.dependsOn bintrayUpload
-bintrayUpload.dependsOn verifyDistributions
-bintrayUpload.mustRunAfter(distTar)
-bintrayUpload.mustRunAfter(distZip)
 apply plugin: 'groovy'


### PR DESCRIPTION
One of `bintray`'s dependencies, `http-builder:0.7.2` started showing up as missing from multiple maven repositories, and this is throwing an error upon running of PEEPS tests. Since `bintray` job appears to be used only for uploading of consensys's packages (which we do not do), we should remove this plugin from our repository. 