### PR TITLE
fix: DSO-3022 Increase await timeout

### DIFF
--- a/dsl/src/main/java/tech/pegasys/peeps/network/Network.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/network/Network.java
@@ -463,7 +463,7 @@ public class Network implements Closeable {
                         .map(node -> node.rpc().getBlockNumber())
                         .allMatch(block -> block >= blockNumber))
                 .isTrue(),
-        120,
+        240,
         "Failed to achieve consensus on block number being at least %s",
         blockNumber);
   }

--- a/dsl/src/main/java/tech/pegasys/peeps/util/Await.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/util/Await.java
@@ -25,7 +25,7 @@ import org.awaitility.core.ThrowingRunnable;
 
 public class Await {
 
-  public static final int DEFAULT_TIMEOUT_IN_SECONDS = 30;
+  public static final int DEFAULT_TIMEOUT_IN_SECONDS = 60;
 
   @FormatMethod
   public static <T> Optional<T> awaitPresence(


### PR DESCRIPTION
The github runners seem to be slower and need a longer timeout for some of the tests to reduce randomness in test results.